### PR TITLE
Remove unused imports from AuthController 

### DIFF
--- a/lms-backend/src/main/java/net/java/lms_backend/controller/AuthController.java
+++ b/lms-backend/src/main/java/net/java/lms_backend/controller/AuthController.java
@@ -1,15 +1,12 @@
 package net.java.lms_backend.controller;
 
-import net.java.lms_backend.Security.Jwt.JwtUtil;
+
 import net.java.lms_backend.Service.AuthService;
 import net.java.lms_backend.dto.LoginRequestDTO;
 import net.java.lms_backend.dto.RegisterDTO;
-import org.springframework.beans.factory.annotation.Autowired;
+
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
+
 import org.springframework.web.bind.annotation.*;
 
 import static net.java.lms_backend.mapper.UserMapper.ToUserLogin;


### PR DESCRIPTION
Closes #1 

This PR **removes unused import statements** from `AuthController.java` as identified by SonarQube in order to improve maintainability.